### PR TITLE
history panel can be scrolled now

### DIFF
--- a/src/net/ofts/vecCalc/history/HistoryFrame.java
+++ b/src/net/ofts/vecCalc/history/HistoryFrame.java
@@ -35,8 +35,8 @@ public class HistoryFrame extends JFrame {
         setVisible(false);
         instance = this;
         contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
-        contentPanel.setSize(275, 350);
-        contentPanel.setPreferredSize(new Dimension(275, 350));
+        //contentPanel.setSize(275, 114514);
+        //contentPanel.setPreferredSize(new Dimension(275, 114514));
         clear = new JButton("Clear History");
         clear.addActionListener(a -> clearHistory());
         clear.setPreferredSize(new Dimension(100, 30));

--- a/src/net/ofts/vecCalc/history/HistoryPanel.java
+++ b/src/net/ofts/vecCalc/history/HistoryPanel.java
@@ -14,8 +14,8 @@ public class HistoryPanel extends JPanel {
         this.item = item;
         this.setBorder(new TitledBorder(item.getOperationName()));
         this.setLayout(new FlowLayout());
-        this.setMaximumSize(new Dimension(275, 105));
-        this.setPreferredSize(new Dimension(275, 105));
+        this.setMaximumSize(new Dimension(285, 105));
+        this.setPreferredSize(new Dimension(285, 105));
 
         button = new JButton("open");
         button.addActionListener(a -> item.openHistory());


### PR DESCRIPTION
# Fixed Issue#6
# Technical Details:
- Content Panel inside the history frame has accidentally been assigned a preferred height and width. 
- When the content exceeds the current height, the history panel is expected to create a scroll bar
- However, since the preferred height is set, the history panel will cut off all the part exceed the height, and thus history panel will never exceed the height, so no scroll bar will be created