### PR TITLE
history can now be recorded and loaded correctly

### DIFF
--- a/src/net/ofts/vecCalc/history/HistoryItem.java
+++ b/src/net/ofts/vecCalc/history/HistoryItem.java
@@ -24,7 +24,7 @@ public class HistoryItem {
     public HistoryItem(String operatorCode, INumber[] operands){
         this.operands = new INumber[operands.length];
         for (int i = 0; i < operands.length; i++) {
-            this.operands[i] = operands[i].clone();
+            this.operands[i] = operands[i] == null ? null : operands[i].clone();
         }
         this.operatorCode = operatorCode;
     }
@@ -32,7 +32,7 @@ public class HistoryItem {
     public HistoryItem(String operatorCode, SuperNumber[] operands){
         this.operands = new INumber[operands.length];
         for (int i = 0; i < operands.length; i++) {
-            this.operands[i] = operands[i].degrade();
+            this.operands[i] = operands[i] == null ? null : operands[i].degrade();
         }
         this.operatorCode = operatorCode;
     }

--- a/src/net/ofts/vecCalc/vector/Vec3ControlPane.java
+++ b/src/net/ofts/vecCalc/vector/Vec3ControlPane.java
@@ -17,7 +17,7 @@ public class Vec3ControlPane extends JPanel {
     @SuppressWarnings("unchecked")
     public static final Class<? extends AbstractNumberPane>[] operandForm = new Class[]{Vec3Pane.class, Vec3Pane.class, NumPane.class, Vec3Pane.class, Vec3Pane.class, BlankPane.class, BlankPane.class, Vec3Pane.class, Vec3Pane.class};
     @SuppressWarnings("unchecked")
-    public static final Class<? extends AbstractNumberPane>[] resultForm = new Class[]{Vec3Pane.class, Vec3Pane.class, Vec3Pane.class, NumPane.class, Vec3Pane.class, Vec3Pane.class, Vec3Pane.class, Vec3Pane.class, Vec3Pane.class};
+    public static final Class<? extends AbstractNumberPane>[] resultForm = new Class[]{Vec3Pane.class, Vec3Pane.class, Vec3Pane.class, NumPane.class, Vec3Pane.class, Vec3Pane.class, NumPane.class, Vec3Pane.class, Vec3Pane.class};
     public int index = 0;
     public Vec3Screen parent;
 


### PR DESCRIPTION
# Fixed issue#7: history cannot be recorder
# Technical Details:
- Now history recorder will not force to record a number. 
- Added null check: if num is null, do not do any operation but record null
# Side Bugfixes:
- Fixed the bug that vector3 calculator uses wrong number panel when calculating length